### PR TITLE
fix: lock anonymous API endpoints (brand deletion incident)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
   db:
     image: mysql:8.0
     ports:
-      - "3306:3306"
+      - "127.0.0.1:3306:3306"
     environment:
       - MYSQL_ROOT_PASSWORD=magento
       - MYSQL_DATABASE=magento
@@ -46,14 +46,14 @@ services:
         soft: 65536
         hard: 65536
     ports:
-      - "9200:9200"
+      - "127.0.0.1:9200:9200"
     volumes:
       - osdata:/usr/share/opensearch/data
 
   redis:
     image: redis:6.2
     ports:
-      - "6380:6379"
+      - "127.0.0.1:6380:6379"
 
 volumes:
   dbdata:

--- a/src/app/code/Formula/Blog/etc/webapi.xml
+++ b/src/app/code/Formula/Blog/etc/webapi.xml
@@ -3,7 +3,7 @@
     <route url="/V1/blog" method="POST">
         <service class="Formula\Blog\Api\BlogRepositoryInterface" method="save"/>
         <resources>
-            <resource ref="anonymous" />
+            <resource ref="Magento_Backend::admin" />
         </resources>
     </route>
     <route url="/V1/blog/:blogId" method="GET">
@@ -24,13 +24,13 @@
     <route url="/V1/blog/:blogId" method="DELETE">
         <service class="Formula\Blog\Api\BlogRepositoryInterface" method="deleteById"/>
         <resources>
-            <resource ref="anonymous" />
+            <resource ref="Magento_Backend::admin" />
         </resources>
     </route>
     <route url="/V1/blog/:blogId" method="PUT">
         <service class="Formula\Blog\Api\BlogRepositoryInterface" method="update"/>
         <resources>
-            <resource ref="anonymous" />
+            <resource ref="Magento_Backend::admin" />
         </resources>
     </route>
 </routes>

--- a/src/app/code/Formula/BodyConcern/etc/webapi.xml
+++ b/src/app/code/Formula/BodyConcern/etc/webapi.xml
@@ -3,7 +3,7 @@
     <route url="/V1/bodyconcern" method="POST">
         <service class="Formula\BodyConcern\Api\BodyConcernRepositoryInterface" method="save"/>
         <resources>
-            <resource ref="anonymous" />
+            <resource ref="Magento_Backend::admin" />
         </resources>
     </route>
     <route url="/V1/bodyconcern/:bodyconcernId" method="GET">
@@ -24,13 +24,13 @@
     <route url="/V1/bodyconcern/:bodyconcernId" method="DELETE">
         <service class="Formula\BodyConcern\Api\BodyConcernRepositoryInterface" method="deleteById"/>
         <resources>
-            <resource ref="anonymous" />
+            <resource ref="Magento_Backend::admin" />
         </resources>
     </route>
     <route url="/V1/bodyconcern/:bodyconcernId" method="PUT">
         <service class="Formula\BodyConcern\Api\BodyConcernRepositoryInterface" method="update"/>
         <resources>
-            <resource ref="anonymous" />
+            <resource ref="Magento_Backend::admin" />
         </resources>
     </route>
 </routes>

--- a/src/app/code/Formula/Brand/Controller/Adminhtml/Brand/MassDelete.php
+++ b/src/app/code/Formula/Brand/Controller/Adminhtml/Brand/MassDelete.php
@@ -34,17 +34,27 @@ class MassDelete extends Action
             // Get selected IDs from mass action
             $ids = $this->getRequest()->getParam('selected');
             if (!$ids) {
-                $ids = $this->getRequest()->getParam('excluded') ? [] : null;
-                if ($ids === null) {
+                $excluded = $this->getRequest()->getParam('excluded');
+                if (!$excluded) {
                     $this->messageManager->addErrorMessage(__('Please select brand(s) to delete.'));
                     return $resultRedirect->setPath('*/*/');
                 }
-                
-                // If excluded is set, get all IDs except excluded ones
+
+                // If excluded is "false" (select-all with no exclusions), require explicit selection
+                if ($excluded === 'false' || (is_array($excluded) && empty(array_filter($excluded)))) {
+                    $this->messageManager->addErrorMessage(__('Please select specific brand(s) to delete. Select-all deletion is disabled for safety.'));
+                    return $resultRedirect->setPath('*/*/');
+                }
+
+                // If excluded has actual IDs, get all IDs except excluded ones
                 $collection = $this->collectionFactory->create();
-                $excluded = $this->getRequest()->getParam('excluded');
-                if ($excluded && $excluded[0] !== '') {
-                    $collection->addFieldToFilter('brand_id', ['nin' => $excluded]);
+                if (is_array($excluded)) {
+                    $excluded = array_filter($excluded, function ($val) {
+                        return $val !== '' && $val !== null;
+                    });
+                    if (!empty($excluded)) {
+                        $collection->addFieldToFilter('brand_id', ['nin' => $excluded]);
+                    }
                 }
                 $ids = $collection->getAllIds();
             }

--- a/src/app/code/Formula/Brand/etc/webapi.xml
+++ b/src/app/code/Formula/Brand/etc/webapi.xml
@@ -3,7 +3,7 @@
     <route url="/V1/brand" method="POST">
         <service class="Formula\Brand\Api\BrandRepositoryInterface" method="save"/>
         <resources>
-            <resource ref="anonymous" />
+            <resource ref="Magento_Backend::admin" />
         </resources>
     </route>
     <route url="/V1/brand/:brandId" method="GET">
@@ -24,13 +24,13 @@
     <route url="/V1/brand/:brandId" method="DELETE">
         <service class="Formula\Brand\Api\BrandRepositoryInterface" method="deleteById"/>
         <resources>
-            <resource ref="anonymous" />
+            <resource ref="Magento_Backend::admin" />
         </resources>
     </route>
     <route url="/V1/brand/:brandId" method="PUT">
         <service class="Formula\Brand\Api\BrandRepositoryInterface" method="update"/>
         <resources>
-            <resource ref="anonymous" />
+            <resource ref="Magento_Backend::admin" />
         </resources>
     </route>
 </routes>

--- a/src/app/code/Formula/CategoryBanners/etc/webapi.xml
+++ b/src/app/code/Formula/CategoryBanners/etc/webapi.xml
@@ -23,23 +23,23 @@
     <route url="/V1/formula-category-banners" method="POST">
         <service class="Formula\CategoryBanners\Api\CategoryBannerRepositoryInterface" method="save"/>
         <resources>
-            <resource ref="anonymous"/>
+            <resource ref="Magento_Backend::admin"/>
         </resources>
     </route>
-    
+
     <!-- Delete a banner -->
     <route url="/V1/formula-category-banners/:id" method="DELETE">
         <service class="Formula\CategoryBanners\Api\CategoryBannerRepositoryInterface" method="deleteById"/>
         <resources>
-            <resource ref="anonymous"/>
+            <resource ref="Magento_Backend::admin"/>
         </resources>
     </route>
-    
+
     <!-- Upload an image for a banner -->
     <route url="/V1/formula-category-banners/image/upload" method="POST">
         <service class="Formula\CategoryBanners\Api\BannerImageUploaderInterface" method="uploadImage"/>
         <resources>
-            <resource ref="anonymous"/>
+            <resource ref="Magento_Backend::admin"/>
         </resources>
     </route>
     

--- a/src/app/code/Formula/CountryFormulaBanners/etc/webapi.xml
+++ b/src/app/code/Formula/CountryFormulaBanners/etc/webapi.xml
@@ -31,23 +31,23 @@
     <route url="/V1/formula-country-banners" method="POST">
         <service class="Formula\CountryFormulaBanners\Api\CountryFormulaBannerRepositoryInterface" method="save"/>
         <resources>
-            <resource ref="anonymous"/>
+            <resource ref="Magento_Backend::admin"/>
         </resources>
     </route>
-    
+
     <!-- Delete a banner -->
     <route url="/V1/formula-country-banners/:id" method="DELETE">
         <service class="Formula\CountryFormulaBanners\Api\CountryFormulaBannerRepositoryInterface" method="deleteById"/>
         <resources>
-            <resource ref="anonymous"/>
+            <resource ref="Magento_Backend::admin"/>
         </resources>
     </route>
-    
+
     <!-- Upload an image for a banner -->
     <route url="/V1/formula-country-banners/image/upload" method="POST">
         <service class="Formula\CountryFormulaBanners\Api\BannerImageUploaderInterface" method="uploadImage"/>
         <resources>
-            <resource ref="anonymous"/>
+            <resource ref="Magento_Backend::admin"/>
         </resources>
     </route>
     

--- a/src/app/code/Formula/FaceConcern/etc/webapi.xml
+++ b/src/app/code/Formula/FaceConcern/etc/webapi.xml
@@ -3,7 +3,7 @@
     <route url="/V1/faceconcern" method="POST">
         <service class="Formula\FaceConcern\Api\FaceConcernRepositoryInterface" method="save"/>
         <resources>
-            <resource ref="anonymous" />
+            <resource ref="Magento_Backend::admin" />
         </resources>
     </route>
     <route url="/V1/faceconcern/:faceconcernId" method="GET">
@@ -24,13 +24,13 @@
     <route url="/V1/faceconcern/:faceconcernId" method="DELETE">
         <service class="Formula\FaceConcern\Api\FaceConcernRepositoryInterface" method="deleteById"/>
         <resources>
-            <resource ref="anonymous" />
+            <resource ref="Magento_Backend::admin" />
         </resources>
     </route>
     <route url="/V1/faceconcern/:faceconcernId" method="PUT">
         <service class="Formula\FaceConcern\Api\FaceConcernRepositoryInterface" method="update"/>
         <resources>
-            <resource ref="anonymous" />
+            <resource ref="Magento_Backend::admin" />
         </resources>
     </route>
 </routes>

--- a/src/app/code/Formula/HairConcern/etc/webapi.xml
+++ b/src/app/code/Formula/HairConcern/etc/webapi.xml
@@ -3,7 +3,7 @@
     <route url="/V1/hairconcern" method="POST">
         <service class="Formula\HairConcern\Api\HairConcernRepositoryInterface" method="save"/>
         <resources>
-            <resource ref="anonymous" />
+            <resource ref="Magento_Backend::admin" />
         </resources>
     </route>
     <route url="/V1/hairconcern/:hairconcernId" method="GET">
@@ -24,13 +24,13 @@
     <route url="/V1/hairconcern/:hairconcernId" method="DELETE">
         <service class="Formula\HairConcern\Api\HairConcernRepositoryInterface" method="deleteById"/>
         <resources>
-            <resource ref="anonymous" />
+            <resource ref="Magento_Backend::admin" />
         </resources>
     </route>
     <route url="/V1/hairconcern/:hairconcernId" method="PUT">
         <service class="Formula\HairConcern\Api\HairConcernRepositoryInterface" method="update"/>
         <resources>
-            <resource ref="anonymous" />
+            <resource ref="Magento_Backend::admin" />
         </resources>
     </route>
 </routes>

--- a/src/app/code/Formula/Ingredient/etc/webapi.xml
+++ b/src/app/code/Formula/Ingredient/etc/webapi.xml
@@ -3,7 +3,7 @@
     <route url="/V1/ingredient" method="POST">
         <service class="Formula\Ingredient\Api\IngredientRepositoryInterface" method="save"/>
         <resources>
-            <resource ref="anonymous" />
+            <resource ref="Magento_Backend::admin" />
         </resources>
     </route>
     <route url="/V1/ingredient/:ingredientId" method="GET">
@@ -24,13 +24,13 @@
     <route url="/V1/ingredient/:ingredientId" method="DELETE">
         <service class="Formula\Ingredient\Api\IngredientRepositoryInterface" method="deleteById"/>
         <resources>
-            <resource ref="anonymous" />
+            <resource ref="Magento_Backend::admin" />
         </resources>
     </route>
     <route url="/V1/ingredient/:ingredientId" method="PUT">
         <service class="Formula\Ingredient\Api\IngredientRepositoryInterface" method="update"/>
         <resources>
-            <resource ref="anonymous" />
+            <resource ref="Magento_Backend::admin" />
         </resources>
     </route>
 </routes>

--- a/src/app/code/Formula/Reel/etc/webapi.xml
+++ b/src/app/code/Formula/Reel/etc/webapi.xml
@@ -3,7 +3,7 @@
     <route url="/V1/reel" method="POST">
         <service class="Formula\Reel\Api\ReelRepositoryInterface" method="save"/>
         <resources>
-            <resource ref="anonymous" />
+            <resource ref="Magento_Backend::admin" />
         </resources>
     </route>
     <route url="/V1/reel/:reelId" method="GET">
@@ -24,13 +24,13 @@
     <route url="/V1/reel/:reelId" method="DELETE">
         <service class="Formula\Reel\Api\ReelRepositoryInterface" method="deleteById"/>
         <resources>
-            <resource ref="anonymous" />
+            <resource ref="Magento_Backend::admin" />
         </resources>
     </route>
     <route url="/V1/reel/:reelId" method="PUT">
         <service class="Formula\Reel\Api\ReelRepositoryInterface" method="update"/>
         <resources>
-            <resource ref="anonymous" />
+            <resource ref="Magento_Backend::admin" />
         </resources>
     </route>
 </routes>

--- a/src/app/code/Formula/SkinType/etc/webapi.xml
+++ b/src/app/code/Formula/SkinType/etc/webapi.xml
@@ -3,7 +3,7 @@
     <route url="/V1/skintype" method="POST">
         <service class="Formula\SkinType\Api\SkinTypeRepositoryInterface" method="save"/>
         <resources>
-            <resource ref="anonymous" />
+            <resource ref="Magento_Backend::admin" />
         </resources>
     </route>
     <route url="/V1/skintype/:skintypeId" method="GET">
@@ -24,13 +24,13 @@
     <route url="/V1/skintype/:skintypeId" method="DELETE">
         <service class="Formula\SkinType\Api\SkinTypeRepositoryInterface" method="deleteById"/>
         <resources>
-            <resource ref="anonymous" />
+            <resource ref="Magento_Backend::admin" />
         </resources>
     </route>
     <route url="/V1/skintype/:skintypeId" method="PUT">
         <service class="Formula\SkinType\Api\SkinTypeRepositoryInterface" method="update"/>
         <resources>
-            <resource ref="anonymous" />
+            <resource ref="Magento_Backend::admin" />
         </resources>
     </route>
 </routes>


### PR DESCRIPTION
## Summary
- **30 mutation endpoints** (POST/PUT/DELETE) across 10 modules changed from `anonymous` to `Magento_Backend::admin` — closes the vulnerability that allowed unauthenticated deletion of all 75 brands on Mar 3
- **MassDelete.php** bug fixed — empty `excluded` param can no longer silently delete all brands
- **Docker ports** (MySQL 3306, OpenSearch 9200, Redis 6380) bound to `127.0.0.1` to prevent external access

## Modules locked (GET stays anonymous for frontend)
Brand, Blog, BodyConcern, FaceConcern, HairConcern, Ingredient, Reel, SkinType, CategoryBanners, CountryFormulaBanners

## Intentionally left anonymous
- BulkCartDelete/BulkCartItemsAdd (guest cart ops)
- RefreshToken (customer auth)
- Shiprocket/Wati webhooks (external callbacks)
- COD orders (customer checkout)
- All GET endpoints

## Test plan
- [ ] `bin/magento setup:di:compile` + `cache:flush` succeeds
- [ ] Anonymous GET `/V1/brand` returns 200
- [ ] Anonymous DELETE `/V1/brand/1` returns 401
- [ ] Frontend loads brands, blogs, concerns, ingredients, reels, skin types
- [ ] Guest cart add/remove still works
- [ ] Admin panel CRUD operations still work with admin token
- [ ] `nmap -p 3306 <server-ip>` shows port filtered/closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)